### PR TITLE
Dynamics Sim Fixes

### DIFF
--- a/flightgoggles_uav_dynamics/CMakeLists.txt
+++ b/flightgoggles_uav_dynamics/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(flightgoggles_uav_dynamics)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++11)
 
 # Default to building in release mode when no options are set
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
- Update the `multicopterDynamicsSim` submodule to include necessary headers so that it compiles.
- Enforce C++11 standard in CMake when compiling.